### PR TITLE
Configure lint-staged and prettier to ignore CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "knex": "knex --cwd ./packages/server",
-    "prettier": "prettier --ignore-path .gitignore \"**/*.+(js|jsx|ts|tsx|json|css)\"",
+    "prettier": "prettier --ignore-path .gitignore \"**/*.+(js|jsx|ts|tsx|json)\"",
     "format": "yarn prettier --write",
     "lint": "yarn workspaces run lint",
     "format:check": "yarn prettier --list-different",
@@ -24,7 +24,7 @@
     "prettier": "^2.6.2"
   },
   "lint-staged": {
-    "**/*.+(js|jsx|ts|tsx|css)": [
+    "**/*.+(js|jsx|ts|tsx)": [
       "yarn validate"
     ],
     "*.--write": "prettier --write"


### PR DESCRIPTION
If a CSS file is changed, lint-staged will pass that to `yarn validate` as an argument, overriding the usual file pattern.
This causes Eslint/Prettier to try to lint the CSS file but we don't have any plugins to parse such files so an error is thrown and the commit fails.

This PR simply excludes the CSS pattern from the lint-staged config (and Prettier).
In a follow up PR we could add something like Stylelint and run that only for CSS files (lint-staged supports multiple scripts separates by file type).