### PR TITLE
edit package.json to fix Heroku builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "packages/*"
   ],
   "engines": {
-    "npm": "please-use-yarn",
     "yarn": ">= 1.19.1",
     "node": ">= 17.3.0"
   },


### PR DESCRIPTION
# Description

Removed     `"npm": "please-use-yarn",` from `engines` in `package.json`, because it breaks Heroku builds. 

<img width="457" alt="image" src="https://user-images.githubusercontent.com/64137994/172050193-7509856e-c51f-412b-9925-4d4793036060.png">
