### PR TITLE
add start script to package.json to fix Heroku deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "stylelint:fix": "yarn stylelint \"**/*.css\" --fix",
     "validate": "yarn prettier:check && yarn lint && yarn stylelint:check",
     "fix": "yarn prettier:fix && yarn lint:fix && yarn stylelint:fix",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "start": "yarn start"
   },
   "devDependencies": {
     "husky": "^7.0.4",


### PR DESCRIPTION
# Description

Adding `"start"` script to package.json, hoping it will fix the app deployment.

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/64137994/172052536-4ecd4223-aef0-4790-82f0-2b4f13a1f7b9.png">

https://dev.to/lawrence_eagles/causes-of-heroku-h10-app-crashed-error-and-how-to-solve-them-3jnl#:~:text=Missing%20Required%20Scripts

