### PR TITLE
Add util function to get API base URL (from client side)

### DIFF
--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:5001

--- a/packages/client/src/utils/getApiBaseUrl.js
+++ b/packages/client/src/utils/getApiBaseUrl.js
@@ -1,0 +1,14 @@
+const getApiBaseUrl = () => {
+  if (
+    process.env.NODE_ENV === 'development' &&
+    !process.env.REACT_APP_API_BASE_URL
+  ) {
+    throw new Error(
+      'The environment variable REACT_APP_API_BASE_URL is not set',
+    );
+  }
+
+  return process.env.REACT_APP_API_BASE_URL;
+};
+
+export default getApiBaseUrl;

--- a/packages/server/bin/www
+++ b/packages/server/bin/www
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+const fs = require('fs')
+const path = require('path')
+const dotenv = require('dotenv')
+
 require('dotenv').config({ path: '../../.env' })
 
 /**
@@ -18,6 +22,18 @@ var port = normalizePort(process.env.API_PORT || '5000');
 
 if (process.env.NODE_ENV === 'production') {
   port = normalizePort(process.env.PORT);
+} else {
+  const clientEnvPath = path.join(__dirname, '..', '..', 'client', '.env');
+
+  if (fs.existsSync(clientEnvPath)) {
+    const data = fs.readFileSync(clientEnvPath, 'utf8');
+    const clientConfig = dotenv.parse(data);
+
+    if (clientConfig.REACT_APP_API_BASE_URL) {
+      const apiBaseUrl = new URL(clientConfig.REACT_APP_API_BASE_URL);
+      port = apiBaseUrl.port;
+    }
+  }
 }
 
 app.set('port', port);


### PR DESCRIPTION
# Description

Closes https://github.com/HackYourFuture-CPH/fp-class20/pull/77
Closes https://github.com/HackYourFuture-CPH/fp-class20/pull/87

With this change the server tries to read the REACT_APP_API_BASE_URL env to resolve the issue that was in the 2 PRs mentioned above.

# How to test?

I tested this by using the util function in the frontend and it worked.
Also, I tested that the server was started with the expected port.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
