### PR TITLE
Build client-side app on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "stylelint:fix": "yarn stylelint \"**/*.css\" --fix",
     "validate": "yarn prettier:check && yarn lint && yarn stylelint:check",
     "fix": "yarn prettier:fix && yarn lint:fix && yarn stylelint:fix",
-    "prepare": "husky install"
+    "heroku-postbuild": "yarn workspace client build && cp -a packages/client/build/. packages/server/public/"
   },
   "devDependencies": {
+    "eslint": "^8.14.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-config-react-app": "^7.0.1",
     "husky": "^7.0.4",
     "lint-staged": "^12.4.0",
     "prettier": "^2.6.2",


### PR DESCRIPTION
# Description

This PR adds support for building the client-side app when deploying to Heroku and then the server will serve the API alongside the static files.

Heroku docs can be found [here](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process).

Note: I removed the `prepare` script because it was also run on Heroku and I don't think it's really needed.

# How to test?

I deployed: https://staging-webshop-class20-fp.herokuapp.com/