### PR TITLE
Css Changes in PageNotFound component 

### DIFF
--- a/packages/client/src/components/PageNotFound/PageNotFound.styles.css
+++ b/packages/client/src/components/PageNotFound/PageNotFound.styles.css
@@ -1,9 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Fredericka+the+Great&family=Montserrat:wght@400;500&display=swap');
 
-.error-page {
-  background-color: #342f2b;
-}
-
 .ufo-pic {
   padding-top: 2rem;
 }
@@ -13,7 +9,7 @@
   background: rgb(35 28 22 / 100%);
   display: flex;
   flex-wrap: wrap;
-  margin: 0 auto;
+  margin: 1.5rem auto;
   mix-blend-mode: normal;
   opacity: 0.8;
   justify-content: space-evenly;


### PR DESCRIPTION
# Description

This PR have changes in pagenotfound component. background colour has been removed because another PR enable to have global CSS styles. https://github.com/HackYourFuture-CPH/fp-class20/pull/128 .

Fixes # (issue)
https://hackyourfuture-dk.atlassian.net/browse/CLASS20-115
# How to test?

Please provide a short summary how your changes can be tested?

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
