### PR TITLE
Fall back to serving React app

### DIFF
--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -16,6 +16,11 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use(`/api/`, router);
 
+// Handle every other route with index.html, which will serve the (compiled) React app.
+app.get('*', function (request, response) {
+  response.sendFile(path.resolve(__dirname, 'public', 'index.html'));
+});
+
 app.use((err, req, res, next) => {
   if (err instanceof HttpError) {
     res.status(err.httpStatus);


### PR DESCRIPTION
# Description

If you tried to access `/contact-us` directly on staging, it would fail.
This PR fixes that by falling back to serving the compiled React app (for unknown server routes).

# How to test?

I have deployed this branch to staging: https://staging-webshop-class20-fp.herokuapp.com/contact-us
