### PR TITLE
CLASS20-125 carousel margin bottom is set

### DIFF
--- a/packages/client/src/components/Carousel/Carousel.styles.css
+++ b/packages/client/src/components/Carousel/Carousel.styles.css
@@ -23,6 +23,7 @@
   max-height: 14.375rem;
   overflow: hidden;
   padding: 1rem;
+  margin-bottom: 1rem;
 }
 
 .right-arrow {


### PR DESCRIPTION
# Description

Styling set up globally with border box provided further changes requirement of carousel styling 

Jira: https://hackyourfuture-dk.atlassian.net/browse/CLASS20-125?atlOrigin=eyJpIjoiMTAyYzM3ZDJhYjQ0NGU3ODg5MWQ4MzlmMjE0OTRmMDAiLCJwIjoiaiJ9

Fixes # margin-bottom

Run yarn client start >> check /product/{id} and carousel box

Please provide a short summary how your changes can be tested?

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
