### PR TITLE
CLASS20-129 product card variant link is modified

### DIFF
--- a/packages/client/src/components/ProductComponent/ProductCard.component.js
+++ b/packages/client/src/components/ProductComponent/ProductCard.component.js
@@ -38,7 +38,7 @@ export const ProductCard = ({ product, variant }) => {
           </button>
         </div>
         <a
-          href={`${product.id}`}
+          href={`/product/${product.id}`}
           target="_blank"
           rel="noreferrer"
           className="product-card-link"


### PR DESCRIPTION
# Description

product card variant link should be modified to /product/${product.id}
Jira: https://hackyourfuture-dk.atlassian.net/browse/CLASS20-129

Fixes # previous link was: /${product.id}

# How to test?

yarn client start >> the result of click on small product cards on all pages should be product page

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
