### PR TITLE
fix pagination change page icons

### DIFF
--- a/packages/client/src/components/Pagination/Pagination.js
+++ b/packages/client/src/components/Pagination/Pagination.js
@@ -12,26 +12,22 @@ function Pagination({ currentPage, pageCount, onPageChange }) {
   }
 
   const nextPage = () => {
-    if (currentPage === pageCount) {
-      onPageChange(1);
-    } else {
+    if (currentPage !== pageCount) {
       onPageChange(currentPage + 1);
     }
   };
 
   const previousPage = () => {
-    if (currentPage === 1) {
-      onPageChange(pageCount);
-    } else {
+    if (currentPage !== 1) {
       onPageChange(currentPage - 1);
     }
   };
 
   return (
     <div className="list-page-number">
-      <button type="button" onClick={previousPage}>
+      <button type="button" onClick={previousPage} disabled={currentPage === 1}>
         <img
-          className="arrow-icon"
+          className={currentPage === 1 ? 'arrow-icon-disabled' : 'arrow-icon'}
           src="/assets/vectors/vector_pagination_left.svg"
           alt="Go to previous page"
         />
@@ -48,9 +44,15 @@ function Pagination({ currentPage, pageCount, onPageChange }) {
           </p>
         </button>
       ))}
-      <button type="button" onClick={nextPage}>
+      <button
+        type="button"
+        onClick={nextPage}
+        disabled={currentPage === pageCount}
+      >
         <img
-          className="arrow-icon"
+          className={
+            currentPage === pageCount ? 'arrow-icon-disabled' : 'arrow-icon'
+          }
           src="/assets/vectors/vector_pagination_right.svg"
           alt="Go to next page"
         />

--- a/packages/client/src/components/Pagination/ProductLists.css
+++ b/packages/client/src/components/Pagination/ProductLists.css
@@ -56,6 +56,12 @@
   padding: 1em;
 }
 
+.arrow-icon-disabled {
+  cursor: none;
+  padding: 1em;
+  opacity: 0.03;
+}
+
 @media screen and (max-width: 857px) {
   .product-lists {
     width: 100%;


### PR DESCRIPTION
# Description
Fixing pagination arrow icons , to not rounding pages.
Please provide a short summary explaining what this PR is about.
This PR disable the arrow icons from changing page , when there is no more page before/after current page.
Fixes # (issue)
https://hackyourfuture-dk.atlassian.net/browse/CLASS20-134?atlOrigin=eyJpIjoiYmZjYzQzNzE3NjgwNGRiYzk0OGFkYjkzYzM2NmYzYzYiLCJwIjoiaiJ9
# How to test?
You need to run the server and client to be able to test it.

Please provide a short summary how your changes can be tested?

# Checklist

- [ yes] I have performed a self-review of my own code
- [ yes] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ yes] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [yes ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ yes] This PR is ready to be merged and not breaking any other functionality
