### PR TITLE
productCard link to product and addToCart function

### DIFF
--- a/packages/client/src/components/ProductComponent/ProductCard.component.js
+++ b/packages/client/src/components/ProductComponent/ProductCard.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useContext, useState } from 'react';
 import './ProductCard.styles.css';
 import './ProductCardVariant.styles.css';
@@ -18,6 +19,26 @@ export const ProductCard = ({ product, variant }) => {
 
   const { cartState, updateCartState } = useContext(CartStateContext);
 
+  const addToCart = (e) => {
+    e.preventDefault();
+
+    console.log('add to cart');
+    console.log('isModalOpen', isModalOpen);
+
+    // updateCartState([
+    //   ...cartState,
+    //   {
+    //     id: product.id,
+    //     quantity: count,
+    //     img: product.pictureUrl,
+    //     size: product.size,
+    //     name: product.name,
+    //     price: product.price,
+    //   },
+    // ]); // TODO: fix when cartstate is fixed
+    toggleModal(true);
+  };
+
   if (variant === 'small') {
     return (
       <div className="product-container-variant">
@@ -37,61 +58,42 @@ export const ProductCard = ({ product, variant }) => {
             />
           </button>
         </div>
+        <div className="product-details-variant">
+          <div className="product-image-variant">
+            <img src={product.pictureUrl} alt={`${product.name}`} />
+          </div>
 
-        <a
-          href={`/product/${product.id}`}
-          target="_blank"
-          rel="noreferrer"
-          className="product-card-link"
-        >
-          <div className="product-details-variant">
-            <div className="product-image-variant">
-              <img src={product.pictureUrl} alt={`${product.name}`} />
-            </div>
-
-            <div className="product-information-variant">
-              <div>
+          <div className="product-information-variant">
+            <div>
+              <a
+                href={`/product/${product.id}`}
+                rel="noreferrer"
+                className="product-card-link"
+              >
                 <h2 className="product-name-variant"> {product.name}</h2>
-              </div>
-              <div>
-                <span className="product-size-variant">
-                  {product.size}g glass jar
-                </span>
+              </a>
+            </div>
+            <div>
+              <span className="product-size-variant">
+                {product.size}g glass jar
+              </span>
 
-                <span className="product-size-variant">
-                  {product.price} DKK
-                </span>
+              <span className="product-size-variant">{product.price} DKK</span>
+            </div>
+            <div className="counter-cart-button-variant">
+              <div className="counter-button-variant">
+                <Counter count={count} setCount={setCount} />
               </div>
-              <div className="counter-cart-button-variant">
-                <div className="counter-button-variant">
-                  <Counter count={count} setCount={setCount} />
-                </div>
-                <Button
-                  label="ADD TO CART "
-                  type="addToCart"
-                  backgroundColor="#53742A"
-                  className="add-to-cart-button-variant"
-                  onClick={() => {
-                    toggleModal(true);
-
-                    updateCartState([
-                      ...cartState,
-                      {
-                        id: product.id,
-                        quantity: count,
-                        img: product.pictureUrl,
-                        size: product.size,
-                        name: product.name,
-                        price: product.price,
-                      },
-                    ]);
-                  }}
-                />
-              </div>
+              <Button
+                label="ADD TO CART "
+                type="addToCart"
+                backgroundColor="#53742A"
+                className="add-to-cart-button-variant"
+                onClick={addToCart}
+              />
             </div>
           </div>
-        </a>
-
+        </div>
         {isModalOpen && (
           <div className="confirmation-modal-variant">
             <ProductCardModal
@@ -99,7 +101,7 @@ export const ProductCard = ({ product, variant }) => {
               productImage={product.pictureUrl}
               productName={product.name}
               count={count}
-              amountOfProducts={cartState.length}
+              // amountOfProducts={cartState.length} // TODO: fix when cartState is fixed
               setCount={setCount}
               price={product.price}
             />
@@ -137,7 +139,13 @@ export const ProductCard = ({ product, variant }) => {
 
           <div className="product-information-large">
             <div>
-              <h2 className="product-name-large"> {product.name}</h2>
+              <a
+                href={`/product/${product.id}`}
+                rel="noreferrer"
+                className="product-card-link"
+              >
+                <h2 className="product-name-large"> {product.name}</h2>
+              </a>
               <p className="product-info-large"> {product.description}</p>
             </div>
 
@@ -156,20 +164,7 @@ export const ProductCard = ({ product, variant }) => {
                 type="addToCart"
                 backgroundColor="#53742A"
                 className="add-to-cart-button-large"
-                onClick={() => {
-                  toggleModal(true);
-                  updateCartState([
-                    ...cartState,
-                    {
-                      id: product.id,
-                      quantity: count,
-                      img: product.pictureUrl,
-                      size: product.size,
-                      name: product.name,
-                      price: product.price,
-                    },
-                  ]);
-                }}
+                onClick={addToCart}
               />
             </div>
           </div>
@@ -183,7 +178,7 @@ export const ProductCard = ({ product, variant }) => {
               count={count}
               setCount={setCount}
               price={product.price}
-              amountOfProducts={cartState.length}
+              // amountOfProducts={cartState.length} // TODO: fix when cartstate is fixed
             />
           </div>
         )}


### PR DESCRIPTION
# Description

**Problem**
A link was hugging the whole product card and taking to a new tab for a ProductPage. It also made the buttons on the ProductCard non-functional. 
**Solution**
Wrapped the link only around the product name.

**Problem**
Opening add-to-cart modal was breaking the whole app as cartState is not iterable. 
**Solution (temporary)**
Commented out the cartState related code until cartState is fixed. 